### PR TITLE
[fl] chore: generate_creative_map works with tagging_results

### DIFF
--- a/.github/workflows/test-filonov.yaml
+++ b/.github/workflows/test-filonov.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -30,9 +30,11 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install pytest coverage
-      - name: Test media-tagging
+      - name: Test filonov
         run: |
           uv pip install -e libs/media_tagging/.[all]
+          uv pip install -e libs/media-fetching/
           uv pip install -e libs/media_similarity/
+          uv pip install -e libs/filonov/
           cd libs/filonov
           pytest tests/unit


### PR DESCRIPTION
When generating creative map re-use tagging results for clustering instead of fetching it from the DB once again.

Update tests for FilonovService:

* remove obsoleted patching
* use fake fetching source

Change-Id: I941476fa674bcb81f70566082e638b3338c7d127