### PR TITLE
[fl] fix: bring back default None value for tagger

### DIFF
--- a/libs/filonov/filonov/__init__.py
+++ b/libs/filonov/filonov/__init__.py
@@ -28,4 +28,4 @@ __all__ = [
   'CreativeMap',
 ]
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'

--- a/libs/filonov/filonov/entrypoints/cli.py
+++ b/libs/filonov/filonov/entrypoints/cli.py
@@ -63,7 +63,7 @@ def main(
       help='Type of tagger',
       case_sensitive=False,
     ),
-  ] = 'gemini',
+  ] = None,
   output_name: Annotated[
     str,
     typer.Option(


### PR DESCRIPTION
Change-Id: I9b414dc504c4005f2ad45c5c0930a3a55207a98c