### PR TITLE
feat: All log-name to all CLI entrypoints and fix tagging / similarity CLIs

### DIFF
--- a/libs/filonov/filonov/__init__.py
+++ b/libs/filonov/filonov/__init__.py
@@ -28,4 +28,4 @@ __all__ = [
   'CreativeMap',
 ]
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/libs/media-fetching/media_fetching/__init__.py
+++ b/libs/media-fetching/media_fetching/__init__.py
@@ -40,4 +40,4 @@ INPUT_MAPPING = {
   'fake': FakeFetchingParameters,
   'dbm': BidManagerFetchingParameters,
 }
-__version__ = '0.3.2'
+__version__ = '0.3.3'

--- a/libs/media-fetching/media_fetching/entrypoints/cli.py
+++ b/libs/media-fetching/media_fetching/entrypoints/cli.py
@@ -22,6 +22,7 @@ import typer
 from garf_executors.entrypoints import utils as garf_utils
 from garf_io import writer as garf_writer
 from media_tagging import media
+from media_tagging.entrypoints import utils as tagging_utils
 from typing_extensions import Annotated
 
 import media_fetching
@@ -39,6 +40,7 @@ def _version_callback(show_version: bool) -> None:
 @typer_app.command(
   context_settings={'allow_extra_args': True, 'ignore_unknown_options': True}
 )
+@tagging_utils.log_shutdown
 def main(
   ctx: typer.Context,
   media_type: Annotated[
@@ -88,6 +90,12 @@ def main(
       help='Level of logging',
     ),
   ] = 'INFO',
+  log_name: Annotated[
+    str,
+    typer.Option(
+      help='Name of logger',
+    ),
+  ] = 'media-fetcher',
   version: Annotated[
     bool,
     typer.Option(
@@ -98,7 +106,9 @@ def main(
     ),
   ] = False,
 ):  # noqa: D103
-  _ = garf_utils.init_logging(loglevel=loglevel.upper(), logger_type=logger)
+  garf_utils.init_logging(
+    loglevel=loglevel.upper(), logger_type=logger, name=log_name
+  )
 
   supported_enrichers = (
     media_fetching.enrichers.enricher.AVAILABLE_MODULES.keys()

--- a/libs/media-fetching/pyproject.toml
+++ b/libs/media-fetching/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "garf-youtube-data-api",
   "garf-bid-manager",
   "google-ads-api-report-fetcher",
-  "garf-executors[bq,sql]>=0.0.7",
+  "garf-executors[bq,sql]>=0.0.12",
   "typer",
 ]
 authors = [

--- a/libs/media_similarity/media_similarity/__init__.py
+++ b/libs/media_similarity/media_similarity/__init__.py
@@ -30,4 +30,4 @@ __all__ = [
   'MediaClusteringRequest',
 ]
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/libs/media_similarity/media_similarity/entrypoints/cli.py
+++ b/libs/media_similarity/media_similarity/entrypoints/cli.py
@@ -77,6 +77,12 @@ LogLevel = Annotated[
     help='Level of logging',
   ),
 ]
+LogName = Annotated[
+  str,
+  typer.Option(
+    help='Name of logger',
+  ),
+]
 
 
 def _version_callback(show_version: bool) -> None:
@@ -88,8 +94,8 @@ def _version_callback(show_version: bool) -> None:
 @typer_app.command(
   context_settings={'allow_extra_args': True, 'ignore_unknown_options': True}
 )
+@tagging_utils.log_shutdown
 def cluster(
-  ctx: typer.Context,
   media_paths: MediaPaths = None,
   input: Input = None,
   media_type: MediaType = 'IMAGE',
@@ -122,6 +128,7 @@ def cluster(
   ] = None,
   logger: Logger = 'rich',
   loglevel: LogLevel = 'INFO',
+  log_name: LogName = 'media-similarity',
   parallel_threshold: Annotated[
     int,
     typer.Option(
@@ -129,8 +136,11 @@ def cluster(
     ),
   ] = 10,
 ):
-  garf_utils.init_logging(logger_type=logger, loglevel=loglevel)
-  extra_parameters = garf_utils.ParamsParser([writer, 'input']).parse(ctx.args)
+  garf_utils.init_logging(logger_type=logger, loglevel=loglevel, name=log_name)
+  media_paths, parameters = tagging_utils.parse_typer_arguments(media_paths)
+  extra_parameters = garf_utils.ParamsParser([writer, 'input']).parse(
+    parameters
+  )
   media_paths = media_paths or tagging_utils.get_media_paths_from_file(
     tagging_utils.InputConfig(path=input, **extra_parameters.get('input'))
   )
@@ -156,6 +166,7 @@ def cluster(
 @typer_app.command(
   context_settings={'allow_extra_args': True, 'ignore_unknown_options': True}
 )
+@tagging_utils.log_shutdown
 def compare(
   ctx: typer.Context,
   media_type: MediaType,
@@ -171,9 +182,13 @@ def compare(
   output: Output = 'comparison_results',
   logger: Logger = 'rich',
   loglevel: LogLevel = 'INFO',
+  log_name: LogName = 'media-similarity',
 ):
-  garf_utils.init_logging(logger_type=logger, loglevel=loglevel)
-  extra_parameters = garf_utils.ParamsParser([writer, 'input']).parse(ctx.args)
+  garf_utils.init_logging(logger_type=logger, loglevel=loglevel, name=log_name)
+  media_paths, parameters = tagging_utils.parse_typer_arguments(media_paths)
+  extra_parameters = garf_utils.ParamsParser([writer, 'input']).parse(
+    parameters
+  )
   media_paths = media_paths or tagging_utils.get_media_paths_from_file(
     tagging_utils.InputConfig(path=input, **extra_parameters.get('input'))
   )
@@ -199,6 +214,7 @@ def compare(
 @typer_app.command(
   context_settings={'allow_extra_args': True, 'ignore_unknown_options': True}
 )
+@tagging_utils.log_shutdown
 def search(
   ctx: typer.Context,
   media_type: MediaType,
@@ -214,9 +230,13 @@ def search(
   output: Output = 'comparison_results',
   logger: Logger = 'rich',
   loglevel: LogLevel = 'INFO',
+  log_name: LogName = 'media-similarity',
 ):
-  garf_utils.init_logging(logger_type=logger, loglevel=loglevel)
-  extra_parameters = garf_utils.ParamsParser([writer, 'input']).parse(ctx.args)
+  garf_utils.init_logging(logger_type=logger, loglevel=loglevel, name=log_name)
+  media_paths, parameters = tagging_utils.parse_typer_arguments(media_paths)
+  extra_parameters = garf_utils.ParamsParser([writer, 'input']).parse(
+    parameters
+  )
   media_paths = media_paths or tagging_utils.get_media_paths_from_file(
     tagging_utils.InputConfig(path=input, **extra_parameters.get('input'))
   )

--- a/libs/media_tagging/media_tagging/__init__.py
+++ b/libs/media_tagging/media_tagging/__init__.py
@@ -28,4 +28,4 @@ __all__ = [
   'MediaTaggingService',
   'MediaTaggingRequest',
 ]
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/libs/media_tagging/media_tagging/entrypoints/cli.py
+++ b/libs/media_tagging/media_tagging/entrypoints/cli.py
@@ -86,6 +86,12 @@ LogLevel = Annotated[
     help='Level of logging',
   ),
 ]
+LogName = Annotated[
+  str,
+  typer.Option(
+    help='Name of logger',
+  ),
+]
 
 Deduplicate = Annotated[
   bool,
@@ -111,8 +117,8 @@ def _version_callback(show_version: bool) -> None:
 @typer_app.command(
   context_settings={'allow_extra_args': True, 'ignore_unknown_options': True}
 )
+@utils.log_shutdown
 def tag(
-  ctx: typer.Context,
   media_type: MediaType,
   media_paths: MediaPaths = None,
   input: Input = None,
@@ -123,16 +129,20 @@ def tag(
   deduplicate: Deduplicate = False,
   logger: Logger = 'rich',
   loglevel: LogLevel = 'INFO',
+  log_name: LogName = 'media-tagger',
   parallel_threshold: ParallelTreshold = 10,
 ) -> None:
   tagging_service = media_tagging_service.MediaTaggingService(
     repositories.SqlAlchemyTaggingResultsRepository(db_uri)
   )
+  media_paths, parameters = utils.parse_typer_arguments(media_paths)
   extra_parameters = garf_utils.ParamsParser(['tagger', writer, 'input']).parse(
-    ctx.args
+    parameters
   )
 
-  logger = garf_utils.init_logging(loglevel=loglevel, logger_type=logger)
+  logger = garf_utils.init_logging(
+    loglevel=loglevel, logger_type=logger, name=log_name
+  )
 
   media_paths = media_paths or utils.get_media_paths_from_file(
     utils.InputConfig(path=input, **extra_parameters.get('input'))
@@ -161,8 +171,8 @@ def tag(
 @typer_app.command(
   context_settings={'allow_extra_args': True, 'ignore_unknown_options': True}
 )
+@utils.log_shutdown
 def describe(
-  ctx: typer.Context,
   media_type: MediaType,
   media_paths: MediaPaths = None,
   input: Input = None,
@@ -173,16 +183,20 @@ def describe(
   deduplicate: Deduplicate = False,
   logger: Logger = 'rich',
   loglevel: LogLevel = 'INFO',
+  log_name: LogName = 'media-tagger',
   parallel_threshold: ParallelTreshold = 10,
 ):
   tagging_service = media_tagging_service.MediaTaggingService(
     repositories.SqlAlchemyTaggingResultsRepository(db_uri)
   )
+  media_paths, parameters = utils.parse_typer_arguments(media_paths)
   extra_parameters = garf_utils.ParamsParser(['tagger', writer, 'input']).parse(
-    ctx.args
+    parameters
   )
 
-  logger = garf_utils.init_logging(loglevel=loglevel, logger_type=logger)
+  logger = garf_utils.init_logging(
+    loglevel=loglevel, logger_type=logger, name=log_name
+  )
 
   media_paths = media_paths or utils.get_media_paths_from_file(
     utils.InputConfig(path=input, **extra_parameters.get('input'))
@@ -224,4 +238,4 @@ def main(
 
 
 if __name__ == '__main__':
-  main()
+  typer_app()

--- a/libs/media_tagging/media_tagging/entrypoints/utils.py
+++ b/libs/media_tagging/media_tagging/entrypoints/utils.py
@@ -16,6 +16,8 @@
 
 """Defines helper functions for media tagging entrypoints."""
 
+import functools
+import logging
 import os
 
 import pandas as pd
@@ -75,3 +77,27 @@ def get_media_paths_from_file(input_config: InputConfig) -> set[str]:
   elif (column_name := input_config.column_name) not in data.columns:
     raise exceptions.MediaTaggingError(f'Column {column_name} not found')
   return set(data[column_name].tolist())
+
+
+def parse_typer_arguments(
+  arguments: list[str] | None,
+) -> tuple[list[str], list[str]]:
+  if not arguments:
+    return [], []
+  found_arguments = []
+  parameters = []
+  for argument in arguments:
+    if argument.startswith('--'):
+      parameters.append(argument)
+    else:
+      found_arguments.append(argument)
+  return found_arguments, parameters
+
+
+def log_shutdown(func):
+  @functools.wraps(func)
+  def fn(*args, **kwargs):
+    func(*args, **kwargs)
+    logging.shutdown()
+
+  return fn

--- a/libs/media_tagging/pyproject.toml
+++ b/libs/media_tagging/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "pillow",
     "smart_open",
     "jq",
-    "garf-executors>=0.0.5",
+    "garf-executors>=0.0.12",
     "pandas",
     "pydantic",
     "SQLalchemy>=2.0.0",


### PR DESCRIPTION
* Ensure that media-tagger / media-similarity CLIs can process both media-types and --input option
* Fix bug with incorrect media-tagger script path
* Fix incorrect name of `filonov` utility in --version check
* All CLI how have `log-name` parameters and fully support Google Cloud Logging

Change-Id: I8bcd5eecb3120c1e18fced033c2f16097e421816