### PR TITLE
[tag] feat: take into account tagging options when persisting results

### DIFF
--- a/libs/media_tagging/media_tagging/__init__.py
+++ b/libs/media_tagging/media_tagging/__init__.py
@@ -28,4 +28,4 @@ __all__ = [
   'MediaTaggingService',
   'MediaTaggingRequest',
 ]
-__version__ = '2.0.2'
+__version__ = '2.1.0'

--- a/libs/media_tagging/media_tagging/media_tagging_service.py
+++ b/libs/media_tagging/media_tagging/media_tagging_service.py
@@ -193,11 +193,11 @@ class MediaTaggingService:
     fetching_request: MediaFetchingRequest,
   ) -> MediaTaggingResponse:
     results = self.repo.get(
-      fetching_request.media_paths,
-      fetching_request.media_type,
-      fetching_request.tagger_type,
-      fetching_request.output,
-      fetching_request.deduplicate,
+      media_paths=fetching_request.media_paths,
+      media_type=fetching_request.media_type,
+      tagger_type=fetching_request.tagger_type,
+      output=fetching_request.output,
+      deduplicate=fetching_request.deduplicate,
     )
     return MediaTaggingResponse(results=results)
 
@@ -277,11 +277,14 @@ class MediaTaggingService:
     tagged_media = []
     if self.repo and (
       tagged_media := self.repo.get(
-        tagging_request.media_paths,
-        tagging_request.media_type,
-        tagging_request.tagger_type,
-        output,
-        deduplicate,
+        media_paths=tagging_request.media_paths,
+        media_type=tagging_request.media_type,
+        tagger_type=tagging_request.tagger_type,
+        output=output,
+        deduplicate=deduplicate,
+        tagging_details=tagging_request.tagging_options.model_dump(
+          exclude_none=True
+        ),
       )
     ):
       logger.info('Reusing %d already tagged media', len(tagged_media))

--- a/libs/media_tagging/media_tagging/taggers/base.py
+++ b/libs/media_tagging/media_tagging/taggers/base.py
@@ -53,7 +53,7 @@ class TaggingOptions(pydantic.BaseModel):
   tags: str | Sequence[str] | None = None
   custom_prompt: str | os.PathLike[str] | None = None
   custom_schema: CustomSchema | None = None
-  no_schema: str | bool = False
+  no_schema: str | bool | None = None
 
   def model_post_init(self, __context__):  # noqa: D105
     if self.tags:

--- a/libs/media_tagging/tests/unit/test_repositories.py
+++ b/libs/media_tagging/tests/unit/test_repositories.py
@@ -25,6 +25,38 @@ class TestSqlAlchemyTaggingResultsRepository:
   def repo(self):
     return repositories.SqlAlchemyTaggingResultsRepository()
 
+  def test_get_takes_into_account_tagging_details(self, repo):
+    tagging_result_1 = tagging_result.TaggingResult(
+      identifier='test1',
+      type='text',
+      tagger='gemini',
+      output='tag',
+      content=[tagging_result.Tag(name='tag1', score=0.1)],
+      tagging_details={'tags': 'tag1'},
+      hash=hashlib.md5(b'test1').hexdigest(),
+    )
+    tagging_result_2 = tagging_result.TaggingResult(
+      identifier='test1',
+      type='text',
+      tagger='gemini',
+      output='tag',
+      content=[tagging_result.Tag(name='tag2', score=0.1)],
+      tagging_details={'n_tags': 1},
+      hash=hashlib.md5(b'test1').hexdigest(),
+    )
+    repo.add(tagging_result_1)
+    repo.add(tagging_result_2)
+
+    tagging_results = repo.get(
+      media_paths='test1',
+      media_type='text',
+      tagger_type='gemini',
+      output='tag',
+      tagging_details={'n_tags': 1},
+    )
+
+    assert len(tagging_results) == 1
+
   def test_get_dedup_tags(self, repo):
     tagging_result_1 = tagging_result.TaggingResult(
       identifier='test1',


### PR DESCRIPTION
Current implementation is to ignore tagging details and return media with the same hash-tagger-output-type regardless of tagging specific details provided. This led to inability save tagging results with tagging details (like custom prompts) due to the fact that already persisted results were fetched from DB.

Change-Id: Ibc1755289994d69dfae0dc362aedae4ad2251c53