### PR TITLE
[fl] fix: propagate tagger parameters while generating maps

### DIFF
--- a/libs/filonov/filonov/__init__.py
+++ b/libs/filonov/filonov/__init__.py
@@ -28,4 +28,4 @@ __all__ = [
   'CreativeMap',
 ]
 
-__version__ = '0.8.2'
+__version__ = '0.8.3'

--- a/libs/filonov/filonov/filonov_service.py
+++ b/libs/filonov/filonov/filonov_service.py
@@ -89,6 +89,10 @@ class CreativeMapGenerateRequest(pydantic.BaseModel):
   context: dict[str, Any] = pydantic.Field(default_factory=dict)
 
   def model_post_init(self, __context):  # noqa: D105
+    if not self.tagger_parameters:
+      self.tagger_parameters = self.default_tagger_parameters
+    if 'n_tags' not in self.tagger_parameters:
+      self.tagger_parameters.update(self.default_tagger_parameters)
     if self.source == 'youtube':
       self.media_type = 'YOUTUBE_VIDEO'
       self.tagger = 'gemini'
@@ -178,7 +182,7 @@ class FilonovService:
         MediaTaggingRequest(
           tagger_type=request.tagger,
           media_type=request.media_type,
-          tagging_options=CreativeMapGenerateRequest.default_tagger_parameters,
+          tagging_options=request.tagger_parameters,
           media_paths=media_urls,
           parallel_threshold=request.parallel_threshold,
           deduplicate=True,

--- a/libs/filonov/tests/unit/test_filonov_service.py
+++ b/libs/filonov/tests/unit/test_filonov_service.py
@@ -51,6 +51,7 @@ class TestCreativeMapGenerateRequest:
     request = filonov_service.CreativeMapGenerateRequest(
       source='fake', tagger_parameters=tagger_parameters
     )
+    expected_parameters.update({'n_tags': 100})
     assert request.tagger_parameters == expected_parameters
 
 


### PR DESCRIPTION
Change-Id: Ib2105f9677e692b33294c5de1883ba93fab153fb