### PR TITLE
[fl] feat: improve modules inclusion when building creative maps

### DIFF
--- a/libs/filonov/filonov/creative_map.py
+++ b/libs/filonov/filonov/creative_map.py
@@ -247,8 +247,12 @@ def convert_report_to_media_info(
     with_size_base = None
 
   if modules:
-    modules = {module.split('.')[1] for module in modules}
-    modules = modules.intersection(performance.column_names)
+    module_elements = {module.split('.')[1] for module in modules}
+    modules = set()
+    for column in performance.column_names:
+      for element in module_elements:
+        if column.startswith(element):
+          modules.add(column)
   else:
     modules = set()
 


### PR DESCRIPTION
Instead of including modules by full match require partial match (column name should start with a module name).

Change-Id: I9717bba5b99da22ed1e0d1b66283bf5a5c1a14dd