### PR TITLE
feat(fl): add celery task processing

### DIFF
--- a/libs/filonov/filonov/entrypoints/server.py
+++ b/libs/filonov/filonov/entrypoints/server.py
@@ -33,7 +33,7 @@ from pydantic_settings import BaseSettings
 from typing_extensions import Annotated
 
 import filonov
-from filonov.entrypoints import utils
+from filonov.entrypoints import tasks
 
 app = fastapi.FastAPI(
   title='Filonov API',
@@ -162,153 +162,201 @@ class GenerateCreativeMapBidManagerRequest(filonov.GenerateCreativeMapRequest):
   source: Literal['dbm'] = 'dbm'
 
 
-@app.post('/dashboard/file')
+@app.get('/api/version')
+async def version() -> str:
+  return filonov.__version__
+
+
+@app.get('/api/info')
+async def info() -> dict[str, str]:
+  return {
+    'filonov': filonov.__version__,
+    'media_tagging': media_tagging.__version__,
+    'media_fetching': media_fetching.__version__,
+    'media_similarity': media_similarity.__version__,
+  }
+
+
+@app.get('/api/operations/{operation_id}')
+def operation_status(operation_id: str):
+  """Gets tagging operation status and results."""
+  operation = tasks.app.AsyncResult(operation_id)
+  return {
+    'operation_id': operation_id,
+    'status': operation.status,
+    'results': operation.result if operation.status == 'SUCCESS' else None,
+  }
+
+
+@app.post('/api/dashboard/file:task')
+def tag_task(
+  request: GenerateTablesFileRequest,
+) -> dict[str, str]:
+  """Sends file-based dashboard generating request to Celery.
+
+  Args:
+    request: Post request for generating dashboard based on file input.
+
+  Returns:
+    Operation id and its status.
+  """
+  task = tasks.create_tables.delay(request.model_dump())
+  return {'operation_id': task.id, 'status': 'PENDING'}
+
+
+@app.post('/api/dashboard/file')
+@app.post('/dashboard/file', deprecated=True)
 def generate_tables_file(
   request: GenerateTablesFileRequest,
-  dependencies: Annotated[Dependencies, fastapi.Depends(Dependencies)],
 ) -> fastapi.responses.JSONResponse:
   """Generates dashboard sources based on a file."""
-  return generate_tables(
-    'file',
-    request,
-    dependencies,
-  )
+  return generate_tables(request)
 
 
-@app.post('/creative_map/file')
+@app.post('/api/creative_map/file:task')
+def generate_creative_map_file_task(
+  request: GenerateCreativeMapFileRequest,
+) -> dict[str, str]:
+  """Generates creative map JSON based on a file."""
+  task = tasks.create_map.delay(request.model_dump())
+  return {'operation_id': task.id, 'status': 'PENDING'}
+
+
+@app.post('/api/creative_map/file')
+@app.post('/creative_map/file', deprecated=True)
 def generate_creative_map_file(
   request: GenerateCreativeMapFileRequest,
-  dependencies: Annotated[Dependencies, fastapi.Depends(Dependencies)],
 ) -> fastapi.responses.JSONResponse:
   """Generates creative map JSON based on a file."""
-  return generate_creative_map(
-    'file',
-    request,
-    dependencies,
-  )
+  return generate_creative_map(request)
 
 
-@app.post('/dashboard/googleads')
+@app.post('/api/dashboard/googleads:task')
+def generate_tables_googleads_task(
+  request: GenerateTablesGoogleAdsRequest,
+) -> dict[str, str]:
+  """Generates dashboard sources based on Google Ads."""
+  task = tasks.create_tables.delay(request.model_dump())
+  return {'operation_id': task.id, 'status': 'PENDING'}
+
+
+@app.post('/api/dashboard/googleads')
+@app.post('/dashboard/googleads', deprecated=True)
 def generate_tables_googleads(
   request: GenerateTablesGoogleAdsRequest,
-  dependencies: Annotated[Dependencies, fastapi.Depends(Dependencies)],
 ) -> fastapi.responses.JSONResponse:
   """Generates dashboard sources based on Google Ads."""
-  return generate_tables(
-    'googleads',
-    request,
-    dependencies,
-  )
+  return generate_tables(request)
 
 
-@app.post('/creative_map/googleads')
+@app.post('/api/creative_map/googleads:task')
+def generate_creative_map_googleads_task(
+  request: GenerateCreativeMapGoogleAdsRequest,
+) -> dict[str, str]:
+  """Generates creative map JSON based on Google Ads."""
+  task = tasks.create_map.delay(request.model_dump())
+  return {'operation_id': task.id, 'status': 'PENDING'}
+
+
+@app.post('/api/creative_map/googleads')
+@app.post('/creative_map/googleads', deprecated=True)
 def generate_creative_map_googleads(
   request: GenerateCreativeMapGoogleAdsRequest,
-  dependencies: Annotated[Dependencies, fastapi.Depends(Dependencies)],
 ) -> fastapi.responses.JSONResponse:
   """Generates creative map JSON based on Google Ads."""
-  return generate_creative_map(
-    'googleads',
-    request,
-    dependencies,
-  )
+  return generate_creative_map(request)
 
 
-@app.post('/dashboard/youtube')
+@app.post('/api/dashboard/youtube:task')
+def generate_tables_youtube_task(
+  request: GenerateTablesYouTubeRequest,
+) -> dict[str, str]:
+  """Generates dashboard sources JSON based on YouTube channel."""
+  task = tasks.create_tables.delay(request.model_dump())
+  return {'operation_id': task.id, 'status': 'PENDING'}
+
+
+@app.post('/api/dashboard/youtube')
+@app.post('/dashboard/youtube', deprecated=True)
 def generate_tables_youtube(
   request: GenerateTablesYouTubeRequest,
-  dependencies: Annotated[Dependencies, fastapi.Depends(Dependencies)],
 ) -> fastapi.responses.JSONResponse:
   """Generates dashboard sources JSON based on YouTube channel."""
-  return generate_tables(
-    'youtube',
-    request,
-    dependencies,
-  )
+  return generate_tables(request)
 
 
-@app.post('/creative_map/youtube')
+@app.post('/api/creative_map/youtube:task')
+def generate_creative_map_youtube_task(
+  request: GenerateCreativeMapYouTubeRequest,
+) -> dict[str, str]:
+  """Generates creative map JSON based on YouTube channel."""
+  task = tasks.create_map.delay(request.model_dump())
+  return {'operation_id': task.id, 'status': 'PENDING'}
+
+
+@app.post('/api/creative_map/youtube')
+@app.post('/creative_map/youtube', deprecated=True)
 def generate_creative_map_youtube(
   request: GenerateCreativeMapYouTubeRequest,
-  dependencies: Annotated[Dependencies, fastapi.Depends(Dependencies)],
 ) -> fastapi.responses.JSONResponse:
   """Generates creative map JSON based on YouTube channel."""
-  return generate_creative_map(
-    'youtube',
-    request,
-    dependencies,
-  )
+  return generate_creative_map(request)
 
 
-@app.post('/dashboard/dbm')
+@app.post('/api/dashboard/dbm:task')
+def generate_tables_dbm_task(
+  request: GenerateTablesBidManagerRequest,
+) -> dict[str, str]:
+  """Generates dashboard sources JSON based on BidManager API."""
+  task = tasks.create_tables.delay(request.model_dump())
+  return {'operation_id': task.id, 'status': 'PENDING'}
+
+
+@app.post('/api/dashboard/dbm')
+@app.post('/dashboard/dbm', deprecated=True)
 def generate_tables_dbm(
   request: GenerateTablesBidManagerRequest,
-  dependencies: Annotated[Dependencies, fastapi.Depends(Dependencies)],
 ) -> fastapi.responses.JSONResponse:
   """Generates dashboard sources JSON based on BidManager API."""
-  return generate_tables(
-    'dbm',
-    request,
-    dependencies,
-  )
+  return generate_tables(request)
 
 
-@app.post('/creative_map/dbm')
+@app.post('/api/creative_map/dbm:task')
+def generate_creative_map_dbm_task(
+  request: GenerateCreativeMapBidManagerRequest,
+) -> dict[str, str]:
+  """Generates creative map JSON based on BidManager API."""
+  task = tasks.create_map.delay(request.model_dump())
+  return {'operation_id': task.id, 'status': 'PENDING'}
+
+
+@app.post('/api/creative_map/dbm')
+@app.post('/creative_map/dbm', deprecated=True)
 def generate_creative_map_dbm(
   request: GenerateCreativeMapBidManagerRequest,
-  dependencies: Annotated[Dependencies, fastapi.Depends(Dependencies)],
 ) -> fastapi.responses.JSONResponse:
   """Generates creative map JSON based on BidManager API."""
-  return generate_creative_map(
-    'dbm',
-    request,
-    dependencies,
-  )
+  return generate_creative_map(request)
 
 
 def generate_creative_map(
-  source: Literal['youtube', 'googleads', 'file'],
   request: filonov.GenerateCreativeMapRequest,
-  dependencies: Annotated[Dependencies, fastapi.Depends(Dependencies)],
-) -> filonov.creative_map.CreativeMapJson:
+) -> fastapi.responses.JSONResponse:
   """Generates creative map JSON based on provided source."""
-  fetching_service = media_fetching.MediaFetchingService.from_source_alias(
-    source=source, **request.source_parameters.model_dump()
-  )
-  generated_map = filonov.FilonovService(
-    fetching_service=fetching_service,
-    tagging_service=dependencies.tagging_service,
-    similarity_service=dependencies.similarity_service,
-  ).generate_creative_map(request)
-
-  if request.output_type == 'file':
-    destination = utils.build_creative_map_destination(request.output_name)
-    generated_map.save(destination)
-    return fastapi.responses.JSONResponse(
-      content=f'Creative map was saved to {destination}.'
-    )
-
+  generated_map = tasks.create_map(request)
   return fastapi.responses.JSONResponse(
-    content=fastapi.encoders.jsonable_encoder(generated_map.to_json())
+    content=fastapi.encoders.jsonable_encoder(generated_map)
   )
 
 
 def generate_tables(
-  source: Literal['youtube', 'googleads', 'file', 'dbm'],
   request: filonov.GenerateTablesRequest,
-  dependencies: Annotated[Dependencies, fastapi.Depends(Dependencies)],
-) -> filonov.creative_map.CreativeMapJson:
+) -> fastapi.responses.JSONResponse:
   """Writes filonov data."""
-  (
-    filonov.FilonovService(
-      fetching_service=media_fetching.MediaFetchingService.from_source_alias(
-        source=source, **request.source_parameters.model_dump()
-      ),
-      tagging_service=dependencies.tagging_service,
-      similarity_service=dependencies.similarity_service,
-    ).generate_tables(request)
+  file_locations = tasks.create_tables(request)
+  return fastapi.responses.JSONResponse(
+    content=fastapi.encoders.jsonable_encoder(file_locations)
   )
-  return fastapi.responses.JSONResponse(content='sources have been created.')
 
 
 @typer_app.command()

--- a/libs/filonov/filonov/entrypoints/tasks.py
+++ b/libs/filonov/filonov/entrypoints/tasks.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import celery
+import media_fetching
+import media_similarity
+import media_tagging
+
+import filonov
+from filonov.entrypoints import utils
+
+redis_url = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+media_tagging_db_url = os.getenv('MEDIA_TAGGING_DB_URL')
+similarity_db_url = os.getenv('SIMILARITY_DB_URL', media_tagging_db_url)
+
+app = celery.Celery(
+  'filonov',
+  broker=redis_url,
+  backend=redis_url,
+)
+
+tagging_service = media_tagging.MediaTaggingService(
+  media_tagging.repositories.SqlAlchemyTaggingResultsRepository(
+    media_tagging_db_url
+  )
+)
+
+similarity_service = media_similarity.MediaSimilarityService(
+  media_similarity_repository=(
+    media_similarity.repositories.SqlAlchemySimilarityPairsRepository(
+      similarity_db_url
+    )
+  )
+)
+
+
+@app.task(pydantic=True)
+def create_map(
+  request: filonov.GenerateCreativeMapRequest,
+) -> filonov.creative_map.CreativeMap:
+  """Writes filonov data to creative map."""
+  generated_map = filonov.FilonovService(
+    fetching_service=media_fetching.MediaFetchingService.from_source_alias(
+      **request.source_parameters.model_dump()
+    ),
+    tagging_service=tagging_service,
+    similarity_service=similarity_service,
+  ).generate_creative_map(request)
+  if request.output_type == 'file':
+    destination = utils.build_creative_map_destination(request.output_name)
+    generated_map.save(destination)
+    return {'location': str(destination)}
+  return generated_map.to_json()
+
+
+@app.task(pydantic=True)
+def create_tables(
+  request: filonov.GenerateTablesRequest,
+) -> dict[str, str]:
+  """Writes filonov data to tables."""
+  return filonov.FilonovService(
+    fetching_service=media_fetching.MediaFetchingService.from_source_alias(
+      **request.source_parameters.model_dump()
+    ),
+    tagging_service=tagging_service,
+    similarity_service=similarity_service,
+  ).generate_tables(request)

--- a/libs/filonov/filonov/filonov_service.py
+++ b/libs/filonov/filonov/filonov_service.py
@@ -84,10 +84,9 @@ class BaseRequest(pydantic.BaseModel):
 
     source_parameters_class = media_fetching.INPUT_MAPPING.get(self.source)
     if not isinstance(self.source_parameters, source_parameters_class):
-      self.source_parameters = source_parameters_class(
-        **self.source_parameters, media_type=self.media_type
-      )
-
+      self.source_parameters = source_parameters_class(**self.source_parameters)
+      if not self.source_parameters.media_type:
+        self.source_parameters.media_type = self.media_type
     self.context.update({self.source: self.source_parameters.model_dump()})
 
 
@@ -226,7 +225,7 @@ class FilonovService:
   def generate_tables(
     self,
     request: GenerateTablesRequest,
-  ) -> None:
+  ) -> dict[str, str]:
     """Generates dashboard data.
 
     Performs the following steps:
@@ -239,7 +238,7 @@ class FilonovService:
       request: Request for creative maps generation.
 
     Returns:
-      Generated creative map.
+      Locations of generated files.
 
     Raises:
       FilonovError: When performance or tagging data not found.
@@ -283,8 +282,16 @@ class FilonovService:
     dashboard_writer = garf_writer.create_writer(
       request.writer, **request.writer_parameters
     )
-    dashboard_writer.write(media_data, 'media_performance')
-    dashboard_writer.write(tags_report, 'tag_performance')
+    media_performance_destination = dashboard_writer.write(
+      media_data, 'media_performance'
+    )
+    tag_performance_destination = dashboard_writer.write(
+      tags_report, 'tag_performance'
+    )
+    return {
+      'media_performance': str(media_performance_destination),
+      'tag_performance': str(tag_performance_destination),
+    }
 
   @tracer.start_as_current_span('generate_creative_map')
   def generate_creative_map(


### PR DESCRIPTION
* add `filonov.entrypoints.tasks` and move processing login there from a server.py
* unify endpoint in `/api`/, mark old onces as deprecated
* generate tables not returns destination paths

Change-Id: I27bd933205e0dbcd84955ecd5b50fceee59f1f58