### PR TITLE
feat(fet): remove youtube connector when working with googleads source

### DIFF
--- a/libs/media-fetching/media_fetching/sources/googleads.py
+++ b/libs/media-fetching/media_fetching/sources/googleads.py
@@ -26,7 +26,6 @@ from typing import Literal, get_args
 
 import pydantic
 from garf.community.google.ads import GoogleAdsApiReportFetcher, api_clients
-from garf.community.google.youtube import YouTubeDataApiReportFetcher
 from garf.core import report
 from media_tagging import media
 
@@ -294,45 +293,24 @@ class Fetcher(models.BaseMediaInfoFetcher):
     Returns:
       Mapping between video id and its information.
     """
-    video_orientations_query = """
+    video_duration_query = """
     SELECT
-      id,
-      player.embedWidth AS width,
-      player.embedHeight AS height
-    FROM videos
+      video.id,
+      video.duration_millis / 1e3 AS duration
+    FROM video
     """
-
-    video_ids = performance['media_url'].to_list(
-      row_type='scalar', distinct=True
-    )
-    video_ids.sort()
-    youtube_api_fetcher = YouTubeDataApiReportFetcher(
-      enable_cache=self.enable_cache,
-    )
-    video_orientations = youtube_api_fetcher.fetch(
-      video_orientations_query,
-      id=video_ids,
-      maxWidth=500,
+    video_durations = self.fetcher.fetch(
+      query_specification=video_duration_query, account=self.accounts
     )
 
-    for row in video_orientations:
-      aspect_ratio = round(int(row.width) / int(row.height), 2)
-      if aspect_ratio > 1:
-        row['orientation'] = 'Landscape'
-      elif aspect_ratio < 1:
-        row['orientation'] = 'Portrait'
-      else:
-        row['orientation'] = 'Square'
-
-    video_orientations = video_orientations.to_dict(
-      key_column='id',
-      value_column='orientation',
+    video_durations = video_durations.to_dict(
+      key_column='video_id',
+      value_column='duration',
       value_column_output='scalar',
     )
     for row in performance:
       video_id = row.media_url
-      row['orientation'] = video_orientations.get(video_id, 0.0)
-      row['duration'] = row.video_duration
+      row['duration'] = video_durations.get(video_id, 0.0)
 
   def _get_campaign_ids_for_countries(self, countries: list[str]) -> list[int]:
     threshold = 0.5

--- a/libs/media-fetching/media_fetching/sources/queries.py
+++ b/libs/media-fetching/media_fetching/sources/queries.py
@@ -84,6 +84,7 @@ class DisplayAssetPerformance(PerformanceQuery):
     campaign.advertising_channel_type AS channel_type,
     ad_group_ad.ad.name AS media_name,
     ad_group_ad.ad.id AS asset_id,
+    '' AS orientation,
     ad_group_ad.ad.image_ad.image_url AS media_url,
     'UNKNOWN' AS format_type,
     ad_group_ad.ad.image_ad.pixel_width / ad_group_ad.ad.image_ad.pixel_height
@@ -129,6 +130,7 @@ class ResponsiveDisplayAssetPerformance(PerformanceQuery):
     campaign.advertising_channel_type AS channel_type,
     asset.name AS media_name,
     asset.id AS asset_id,
+    asset.orientation AS orientation,
     asset.image_asset.full_size.url AS media_url,
     ad_group_ad_asset_view.field_type AS format_type,
     asset.image_asset.full_size.width_pixels /
@@ -219,6 +221,7 @@ class PmaxAssetPerformance(PerformanceQuery):
     campaign.id AS campaign_id,
     campaign.advertising_channel_type AS channel_type,
     asset.id AS asset_id,
+    asset.orientation AS orientation,
     {media_name} AS media_name,
     {media_url} AS media_url,
     asset_group_asset.field_type AS format_type,
@@ -283,6 +286,7 @@ class SearchAssetPerformance(PerformanceQuery):
     campaign.advertising_channel_type AS channel_type,
     asset.text_asset.text AS media_name,
     asset.id AS asset_id,
+    asset.orientation AS orientation,
     asset.text_asset.text AS media_url,
     ad_group_ad_asset_view.field_type AS format_type,
     0 AS aspect_ratio,
@@ -327,6 +331,7 @@ class DemandGenTextAssetPerformance(PerformanceQuery):
     campaign.advertising_channel_type AS channel_type,
     asset.text_asset.text AS media_name,
     asset.id AS asset_id,
+    asset.orientation AS orientation,
     asset.text_asset.text AS media_url,
     ad_group_ad_asset_view.field_type AS format_type,
     0 AS aspect_ratio,
@@ -372,6 +377,7 @@ class DemandGenImageAssetPerformance(PerformanceQuery):
     campaign.advertising_channel_type AS channel_type,
     asset.name AS media_name,
     asset.id AS asset_id,
+    asset.orientation AS orientation,
     asset.image_asset.full_size.url AS media_url,
     ad_group_ad_asset_view.field_type AS format_type,
     asset.image_asset.full_size.width_pixels /
@@ -418,22 +424,25 @@ class DemandGenVideoAssetPerformance(PerformanceQuery):
     segments.date AS date,
     campaign.id AS campaign_id,
     campaign.advertising_channel_type AS channel_type,
-    video.id AS media_url,
-    video.title AS media_name,
-    segments.ad_format_type AS format_type,
+    asset.text_asset.text AS media_name,
+    asset.id AS asset_id,
+    asset.orientation AS orientation,
+    asset.youtube_video_asset.youtube_video_id AS media_url,
+    ad_group_ad_asset_view.field_type AS format_type,
     0 AS aspect_ratio,
-    video.duration_millis / 1000 AS video_duration,
-    ad_group_ad.policy_summary.approval_status AS approval_status,
+    0 AS file_size,
+    ad_group_ad.ad.name AS ad_name,
+    ad_group_ad_asset_view.policy_summary:approval_status AS approval_status,
     metrics.cost_micros / 1e6 AS cost,
     metrics.clicks AS clicks,
     metrics.impressions AS impressions,
     metrics.conversions AS conversions,
     metrics.conversions_value AS conversions_value
-  FROM video
+  FROM ad_group_ad_asset_view
   WHERE
     campaign.advertising_channel_type =  DEMAND_GEN
+    AND asset.type = YOUTUBE_VIDEO
     AND segments.date BETWEEN '{start_date}' AND '{end_date}'
-    AND video.id != ''
     AND metrics.cost_micros > {min_cost}
     {campaign_ids}
   """
@@ -459,6 +468,7 @@ class AppAssetPerformance(PerformanceQuery):
     segments.date AS date,
     campaign.id AS campaign_id,
     asset.id AS asset_id,
+    asset.orientation AS orientation,
     {media_name} AS media_name,
     {media_url} AS media_url,
     ad_group_ad_asset_view.field_type AS format_type,

--- a/libs/media-fetching/media_fetching/sources/youtube.py
+++ b/libs/media-fetching/media_fetching/sources/youtube.py
@@ -50,7 +50,9 @@ class Fetcher(models.BaseMediaInfoFetcher):
     fetching_request: YouTubeFetchingParameters,
   ) -> report.GarfReport:
     """Get all public videos from YouTube channel."""
-    youtube_api_fetcher = YouTubeDataApiReportFetcher(**fetching_request)
+    youtube_api_fetcher = YouTubeDataApiReportFetcher(
+      **fetching_request.model_dump()
+    )
     channel_uploads_playlist_query = """
     SELECT
       contentDetails.relatedPlaylists.uploads AS uploads_playlist

--- a/libs/media-fetching/media_fetching/version.py
+++ b/libs/media-fetching/media_fetching/version.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '0.6.3'
+__version__ = '0.6.4'


### PR DESCRIPTION
* Use googleads's asset.orietation to be video orientation
* Update demandgen video performance query
* Ensure that youtube report fetcher is initialized correctly for youtube source

Change-Id: Ie182c95d3500b1760e7e5d019b3d782646bcf2f0